### PR TITLE
Display swap status badges in messages

### DIFF
--- a/skillio/messages.html
+++ b/skillio/messages.html
@@ -50,6 +50,21 @@
     .reply-box button { padding: 8px 16px; background-color: #00bcd4; border: none; color: white; border-radius: 8px;
                         cursor: pointer; font-size: 1rem; }
     .reply-box button:hover { background-color: #0097a7; }
+
+    .swap-status-badge {
+      display: inline-block;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 12px;
+      color: #fff;
+      margin-left: 8px;
+    }
+    .status-accepted { background-color: #28a745; }
+    .status-declined { background-color: #dc3545; }
+    .status-pending_payment,
+    .status-pending { background-color: #ffc107; color: #212529; }
+    .status-cancelled { background-color: #6c757d; }
+
     .swap-button {
       background-color: #00bcd4;
       color: white;
@@ -1015,6 +1030,7 @@
       messageDiv.innerHTML = `
         <div style="margin-bottom: 10px;">
           <strong>Swap Request - $${paymentAmount}</strong>
+          <span class="swap-status-badge" data-status-badge>${swapStatus}</span>
           <span style="float: right; color: #666; font-size: 12px;">
             ${message.timestamp ? new Date(message.timestamp.toDate()).toLocaleString() : 'Just now'}
           </span>
@@ -1028,37 +1044,50 @@
         </div>
         <div style="margin-bottom: 10px; font-size: 12px; color: #666;">
           <strong>Payment Status:</strong> <span style="color: ${statusColor}; font-weight: bold;">${statusText}</span><br>
-          <strong>Swap Status:</strong> ${swapStatus}<br>
+          <strong>Swap Status:</strong> <span data-swap-status-text>${swapStatus}</span><br>
           <strong>Auto-release:</strong> ${swapData?.autoReleaseTime ? new Date(swapData.autoReleaseTime.toDate()).toLocaleString() : 'Not set'}
         </div>
         <div style="display: flex; gap: 10px; flex-wrap: wrap;">
           ${paymentStatus === 'paid' ? `
-            <button onclick="respondToSwap('${message.swapId}', 'accepted')" 
+            <button onclick="respondToSwap('${message.swapId}', 'accepted')"
                     style="background: #28a745; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
               Accept
             </button>
-            <button onclick="respondToSwap('${message.swapId}', 'declined')" 
+            <button onclick="respondToSwap('${message.swapId}', 'declined')"
                     style="background: #dc3545; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
               Decline
             </button>
           ` : `
-            <button onclick="simulatePaymentSuccess('${message.swapId}', ${paymentAmount}, '${swapData?.to || ''}', '${swapData?.toName || ''}')" 
+            <button onclick="simulatePaymentSuccess('${message.swapId}', ${paymentAmount}, '${swapData?.to || ''}', '${swapData?.toName || ''}')"
                     style="background: #007bff; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
               Simulate Payment
             </button>
           `}
-          <button onclick="openDisputeForm('${message.swapId}', ${JSON.stringify(swapData)})" 
+          <button onclick="openDisputeForm('${message.swapId}', ${JSON.stringify(swapData)})"
                   style="background: #ffc107; color: #212529; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
             Dispute
           </button>
           ${paymentStatus === 'paid' ? `
-            <button onclick="simulatePaymentRelease('${message.swapId}')" 
+            <button onclick="simulatePaymentRelease('${message.swapId}')"
                     style="background: #17a2b8; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
               Release Payment
             </button>
           ` : ''}
         </div>
       `;
+
+      const statusBadge = messageDiv.querySelector('[data-status-badge]');
+      const statusTextElement = messageDiv.querySelector('[data-swap-status-text]');
+      function updateStatus(status) {
+        statusBadge.textContent = status;
+        statusBadge.className = 'swap-status-badge status-' + status;
+        if (statusTextElement) statusTextElement.textContent = status;
+      }
+      updateStatus(swapStatus);
+      db.collection('swaps').doc(message.swapId).onSnapshot(doc => {
+        const newStatus = doc.data()?.status || 'pending_payment';
+        updateStatus(newStatus);
+      });
 
       return messageDiv;
     }


### PR DESCRIPTION
## Summary
- show swap status badges next to swap request titles
- style swap status badges with dynamic colors
- update badges in real time when swap status changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d4ba7c488320b48a995fe8f87665